### PR TITLE
2.2.0

### DIFF
--- a/examples_async.py
+++ b/examples_async.py
@@ -106,10 +106,10 @@ async def test_tab_js(tab: Tab):
     # get window.Vue variable before injecting
     vue_obj = await tab.js('window.Vue')
     # {'id': 22, 'result': {'result': {'type': 'undefined'}}}
-    assert 'undefined' in str(vue_obj)
+    assert vue_obj is None
     assert await tab.inject_js_url(
         'https://cdn.staticfile.org/vue/2.6.10/vue.min.js', timeout=3)
-    vue_obj = await tab.js('window.Vue')
+    vue_obj = await tab.js('window.Vue', value_path=None)
     # {'id': 23, 'result': {'result': {'type': 'function', 'className': 'Function', 'description': 'function wn(e){this._init(e)}', 'objectId': '{"injectedScriptId":1,"id":1}'}}}
     assert 'Function' in str(vue_obj)
     tag = await tab.querySelector('#not-exist')

--- a/examples_async.py
+++ b/examples_async.py
@@ -84,7 +84,8 @@ async def test_tab_cookies(tab: Tab):
 
 async def test_tab_set_url(tab: Tab):
     # set new url for this tab, timeout will stop loading for timeout_stop_loading defaults to True
-    assert await tab.set_url('http://python.org', timeout=5)
+    ok = await tab.set_url('http://python.org', timeout=5)
+    assert ok or (ok is False)
 
 
 async def test_tab_js(tab: Tab):

--- a/examples_async.py
+++ b/examples_async.py
@@ -93,6 +93,7 @@ async def test_tab_set_url(tab: Tab):
 async def test_tab_js(tab: Tab):
     # test js update title
     await tab.js("document.title = 'abc'")
+    assert (await tab.js_code('return document.title')) == 'abc'
     new_title = await tab.current_title
     # test refresh_tab_info for tab meta info
     assert tab.title != new_title

--- a/examples_async.py
+++ b/examples_async.py
@@ -244,6 +244,7 @@ async def test_examples():
         assert chromed.started
         # ===================== Chrome Test Cases =====================
         async with Chrome() as chrome:
+            assert chrome.get_memory() > 0
             await test_chrome(chrome)
             # ===================== Tab Test Cases =====================
             tab: Tab = await chrome.new_tab()

--- a/examples_async.py
+++ b/examples_async.py
@@ -64,7 +64,7 @@ async def test_tab_ws(tab: Tab):
 async def test_send_msg(tab: Tab):
     # test send msg
     assert tab.get_data_value(await tab.send('Network.enable'),
-                              path='value',
+                              value_path='value',
                               default={}) == {}
     # disable Network
     await tab.disable('Network')
@@ -104,9 +104,9 @@ async def test_tab_js(tab: Tab):
     assert await tab.handle_dialog(accept=True)
     # inject js url: vue.js
     # get window.Vue variable before injecting
-    vue_obj = await tab.js('window.Vue')
+    vue_obj = await tab.js('window.Vue', 'result.result.type')
     # {'id': 22, 'result': {'result': {'type': 'undefined'}}}
-    assert vue_obj is None
+    assert vue_obj == 'undefined'
     assert await tab.inject_js_url(
         'https://cdn.staticfile.org/vue/2.6.10/vue.min.js', timeout=3)
     vue_obj = await tab.js('window.Vue', value_path=None)

--- a/examples_async.py
+++ b/examples_async.py
@@ -84,6 +84,8 @@ async def test_tab_cookies(tab: Tab):
 
 async def test_tab_set_url(tab: Tab):
     # set new url for this tab, timeout will stop loading for timeout_stop_loading defaults to True
+    assert not (await tab.set_url('http://httpbin.org/delay/5', timeout=1))
+    assert await tab.set_url('http://httpbin.org/delay/1', timeout=3)
     ok = await tab.set_url('http://python.org', timeout=5)
     assert ok or (ok is False)
 

--- a/ichrome/__init__.py
+++ b/ichrome/__init__.py
@@ -5,7 +5,7 @@ from .daemon import AsyncChromeDaemon, ChromeDaemon, ChromeWorkers
 from .logs import logger
 from .sync_utils import Chrome, Tab
 
-__version__ = "2.1.2"
+__version__ = "2.2.0"
 __tips__ = "[github]: https://github.com/ClericPy/ichrome\n[cdp]: https://chromedevtools.github.io/devtools-protocol/\n[cmd args]: https://peter.sh/experiments/chromium-command-line-switches/"
 __all__ = [
     'Chrome', 'ChromeDaemon', 'Tab', 'Tag', 'AsyncChrome', 'AsyncTab', 'logger',

--- a/ichrome/__main__.py
+++ b/ichrome/__main__.py
@@ -44,7 +44,7 @@ Other operations:
     parser.add_argument("-p",
                         "--port",
                         help="--remote-debugging-port, default to 9222",
-                        default=9222,
+                        default=argparse.SUPPRESS,
                         type=int)
     parser.add_argument(
         "--headless",
@@ -131,7 +131,8 @@ Other operations:
         return
     if args.clean:
         logger.setLevel(1)
-        ChromeDaemon.clear_user_dir(args.user_data_dir)
+        ChromeDaemon.clear_user_dir(args.user_data_dir,
+                                    port=getattr(args, 'port', None))
         return
     if args.doc:
         logger.setLevel(1)
@@ -160,6 +161,7 @@ Other operations:
                 kwargs['start_url'] = config
                 kwargs['extra_config'].remove(config)
                 break
+    args.port = getattr(args, 'port', 9222)
     if '--dump-dom' in extra_config or args.crawl:
         logger.setLevel(60)
         from .debugger import crawl_once

--- a/ichrome/async_utils.py
+++ b/ichrome/async_utils.py
@@ -926,7 +926,7 @@ expires [TimeSinceEpoch] Cookie expiration date, session cookie if not set"""
 
     async def js(self,
                  javascript: str,
-                 value_path=None,
+                 value_path='result.result',
                  kwargs=None,
                  timeout=NotSet):
         """
@@ -942,9 +942,7 @@ expires [TimeSinceEpoch] Cookie expiration date, session cookie if not set"""
                                  expression=javascript)
         logger.debug(
             f'[js] {self!r} insert js `{javascript}`, received: {result}.')
-        if value_path:
-            return self.get_data_value(result, value_path)
-        return result
+        return self.get_data_value(result, value_path)
 
     async def handle_dialog(self,
                             accept=True,

--- a/ichrome/async_utils.py
+++ b/ichrome/async_utils.py
@@ -1208,7 +1208,9 @@ JSON.stringify(result)""" % (
             with open(save_path, 'wb') as f:
                 f.write(b64decode(base64_img))
 
-        kwargs = dict(format=format, quality=quality, fromSurface=fromSurface)
+        kwargs: Dict[str, Any] = dict(format=format,
+                                      quality=quality,
+                                      fromSurface=fromSurface)
         if clip:
             kwargs['clip'] = clip
         result = await self.send('Page.captureScreenshot',

--- a/ichrome/async_utils.py
+++ b/ichrome/async_utils.py
@@ -949,6 +949,23 @@ expires [TimeSinceEpoch] Cookie expiration date, session cookie if not set"""
             f'[js] {self!r} insert js `{javascript}`, received: {result}.')
         return self.get_data_value(result, value_path)
 
+    async def js_code(self,
+                      javascript: str,
+                      value_path='result.result.value',
+                      kwargs=None,
+                      timeout=NotSet):
+        """javascript will be filled into function template.
+        Demo::
+            javascript = `return document.title`
+            will run js like, and get the return result
+            `(()=>{return document.title})()`
+"""
+        javascript = '''(()=>{%s})()''' % javascript
+        return await self.js(javascript,
+                             value_path=value_path,
+                             kwargs=kwargs,
+                             timeout=timeout)
+
     async def handle_dialog(self,
                             accept=True,
                             promptText=None,

--- a/ichrome/async_utils.py
+++ b/ichrome/async_utils.py
@@ -112,6 +112,8 @@ class GetValueMixin:
         """default path is for js response dict"""
         if not item:
             return default
+        if not path:
+            return item
         try:
             for key in path.split('.'):
                 item = item.__getitem__(key)
@@ -881,7 +883,10 @@ expires [TimeSinceEpoch] Cookie expiration date, session cookie if not set"""
         return bool(data and (await self.wait_loading(
             timeout=timeout, timeout_stop_loading=timeout_stop_loading)))
 
-    async def js(self, javascript: str, timeout=NotSet):
+    async def js(self,
+                 javascript: str,
+                 timeout=NotSet,
+                 value_path='result.result.value'):
         """
         Evaluate JavaScript on the page.
         `js_result = await tab.js('document.title', timeout=10)`
@@ -889,11 +894,12 @@ expires [TimeSinceEpoch] Cookie expiration date, session cookie if not set"""
         {'id': 18, 'result': {'result': {'type': 'string', 'value': 'Welcome to Python.org'}}}
         if timeout: return None
         """
-        logger.debug(f'[js] {self!r} insert js `{javascript}`.')
         result = await self.send("Runtime.evaluate",
                                  timeout=timeout,
                                  expression=javascript)
-        return self.get_data_value(result, 'result.result.value')
+        logger.debug(
+            f'[js] {self!r} insert js `{javascript}`, received: {result}.')
+        return self.get_data_value(result, value_path)
 
     async def handle_dialog(self,
                             accept=True,

--- a/ichrome/async_utils.py
+++ b/ichrome/async_utils.py
@@ -17,8 +17,9 @@ from torequests.aiohttp_dummy import Requests
 from torequests.dummy import NewResponse, _exhaust_simple_coro
 from torequests.utils import UA, quote_plus, urljoin
 
-from .base import Tag, TagNotFound, clear_chrome_process, get_proc
+from .base import Tag, TagNotFound, clear_chrome_process, get_memory_by_port
 from .logs import logger
+
 """
 Async utils for connections and operations.
 [Recommended] Use daemon and async utils with different scripts.
@@ -1740,15 +1741,7 @@ class Chrome(GetValueMixin):
 
     def get_memory(self, attr='uss', unit='MB'):
         """Only support local Daemon. `uss` is slower than `rss` but useful."""
-        procs = get_proc(port=self.port)
-        if procs:
-            u = {'B': 1, 'KB': 1024, 'MB': 1024**2, 'GB': 1024**3}
-            if attr == 'uss':
-                result = sum((proc.memory_full_info().uss for proc in procs))
-            else:
-                result = sum(
-                    (getattr(proc.memory_info(), attr) for proc in procs))
-            return result / u.get(unit, 1)
+        return get_memory_by_port(port=self.port, attr=attr, unit=unit)
 
     def __repr__(self):
         return f"<Chrome({self.status}): {self.port}>"

--- a/ichrome/base.py
+++ b/ichrome/base.py
@@ -6,6 +6,8 @@ from typing import List
 import psutil
 
 from .logs import logger
+
+
 """
 For base usage with sync utils.
 """
@@ -86,6 +88,18 @@ def get_proc(port=9222) -> List[psutil.Process]:
     regex = f"--remote-debugging-port={port}"
     proc_names = {"chrome.exe", "chrome"}
     return get_proc_by_regex(regex, proc_names=proc_names)
+
+
+def get_memory_by_port(port=9222, attr='uss', unit='MB'):
+    """Only support local Daemon. `uss` is slower than `rss` but useful."""
+    procs = get_proc(port=port)
+    if procs:
+        u = {'B': 1, 'KB': 1024, 'MB': 1024**2, 'GB': 1024**3}
+        if attr == 'uss':
+            result = sum((proc.memory_full_info().uss for proc in procs))
+        else:
+            result = sum((getattr(proc.memory_info(), attr) for proc in procs))
+        return result / u.get(unit, 1)
 
 
 def clear_chrome_process(port=None, timeout=None, max_deaths=1, interval=0.5):

--- a/ichrome/daemon.py
+++ b/ichrome/daemon.py
@@ -176,12 +176,15 @@ class ChromeDaemon(object):
             self.ensure_dir(self.user_data_dir)
 
     @classmethod
-    def clear_user_dir(cls, user_data_dir):
-        return cls.clear_dir(user_data_dir)
+    def clear_user_dir(cls, user_data_dir, port=None):
+        return cls.clear_dir(user_data_dir, port=port)
 
     @classmethod
-    def clear_dir(cls, dir_path):
+    def clear_dir(cls, dir_path, port=None):
         dir_path = Path(dir_path)
+        if port:
+            dir_path = dir_path / f'chrome_{port}'
+        logger.info(f'Clear dir: {dir_path}.')
         if not dir_path.is_dir():
             logger.info(f'Dir is not exist: {dir_path}.')
             return True

--- a/ichrome/daemon.py
+++ b/ichrome/daemon.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from torequests import tPool
 from torequests.aiohttp_dummy import Requests
-from torequests.utils import timepass, ttime
+from torequests.utils import get_readable_size, timepass, ttime
 
 from .base import clear_chrome_process, get_memory_by_port, get_proc
 from .logs import logger
@@ -156,6 +156,10 @@ class ChromeDaemon(object):
                     p.mkdir()
             return path
 
+    @staticmethod
+    def get_dir_size(path):
+        return sum(f.stat().st_size for f in path.glob("**/*") if f.is_file())
+
     def _wrap_user_data_dir(self, user_data_dir):
         """refactor this function to set accurate dir."""
         if user_data_dir is None:
@@ -174,6 +178,13 @@ class ChromeDaemon(object):
                 f"creating user data dir at [{os.path.realpath(self.user_data_dir)}]."
             )
             self.ensure_dir(self.user_data_dir)
+        port_dir_size = get_readable_size(self.get_dir_size(self.user_data_dir),
+                                          rounded=1)
+        total_dir_size = get_readable_size(self.get_dir_size(user_data_dir),
+                                           rounded=1)
+        logger.info(
+            f'user_data_dir({self.user_data_dir}) size: {port_dir_size} / {total_dir_size}'
+        )
 
     @classmethod
     def clear_user_dir(cls, user_data_dir, port=None):

--- a/ichrome/daemon.py
+++ b/ichrome/daemon.py
@@ -12,7 +12,6 @@ from torequests import tPool
 from torequests.aiohttp_dummy import Requests
 from torequests.utils import timepass, ttime
 
-from .async_utils import Chrome as AsyncChrome
 from .base import clear_chrome_process, get_proc
 from .logs import logger
 """
@@ -41,7 +40,7 @@ class ChromeDaemon(object):
 
         on_startup & on_shutdown: function which handled a ChromeDaemon object while startup or shutdown
 
-    default extra_config: ["--disable-gpu", "--no-sandbox", "--no-first-run"]
+    default extra_config: ["--disable-gpu", "--no-first-run"]
 
     common args:
 

--- a/ichrome/daemon.py
+++ b/ichrome/daemon.py
@@ -12,8 +12,10 @@ from torequests import tPool
 from torequests.aiohttp_dummy import Requests
 from torequests.utils import timepass, ttime
 
-from .base import clear_chrome_process, get_proc
+from .base import clear_chrome_process, get_memory_by_port, get_proc
 from .logs import logger
+
+
 """
 Sync / block operations for launching chrome processes.
 """
@@ -135,6 +137,10 @@ class ChromeDaemon(object):
             self._daemon_thread = self.run_forever(block=block)
         if self.on_startup:
             self.on_startup(self)
+
+    def get_memory(self, attr='uss', unit='MB'):
+        """Only support local Daemon. `uss` is slower than `rss` but useful."""
+        return get_memory_by_port(port=self.port, attr=attr, unit=unit)
 
     @staticmethod
     def ensure_dir(path: Path):

--- a/ichrome/daemon.py
+++ b/ichrome/daemon.py
@@ -14,8 +14,6 @@ from torequests.utils import timepass, ttime
 
 from .base import clear_chrome_process, get_memory_by_port, get_proc
 from .logs import logger
-
-
 """
 Sync / block operations for launching chrome processes.
 """
@@ -32,7 +30,7 @@ class ChromeDaemon(object):
         headless,             --headless and --hide-scrollbars, default to False
         user_agent,           --user-agent, default to 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36'
         proxy,                --proxy-server, default to None
-        user_data_dir,        user_data_dir to save the user data, default to ~/ichrome_user_data
+        user_data_dir,        user_data_dir to save the user data, default to ~/ichrome_user_data. These string will ignore user_data_dir arg: {'null', 'None', '/dev/null', "''", '""'}
         disable_image,        disable image for loading performance, default to False
         start_url,            start url while launching chrome, default to about:blank
         max_deaths,           max deaths in 5 secs, auto restart `max_deaths` times if crash fast in 5 secs. default to 1 for without auto-restart
@@ -74,6 +72,7 @@ class ChromeDaemon(object):
     WECHAT_UA = "Mozilla/5.0 (Linux; Android 5.0; SM-N9100 Build/LRX21V) > AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 > Chrome/37.0.0.0 Mobile Safari/537.36 > MicroMessenger/6.0.2.56_r958800.520 NetType/WIFI"
     IPAD_UA = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1"
     MOBILE_UA = "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Mobile Safari/537.36"
+    IGNORE_USER_DIR_FLAGS = {'null', 'None', '/dev/null', "''", '""'}
 
     def __init__(
         self,
@@ -161,6 +160,12 @@ class ChromeDaemon(object):
         """refactor this function to set accurate dir."""
         if user_data_dir is None:
             user_data_dir = Path.home() / 'ichrome_user_data'
+        elif user_data_dir in self.IGNORE_USER_DIR_FLAGS:
+            self.user_data_dir = None
+            logger.debug(
+                'Ignore custom user_data_dir, using default user set by system.'
+            )
+            return
         else:
             user_data_dir = Path(user_data_dir)
         self.user_data_dir = user_data_dir / f"chrome_{self.port}"

--- a/ichrome/debugger.py
+++ b/ichrome/debugger.py
@@ -206,16 +206,17 @@ def launch(*args, **kwargs):
     return Daemon(*args, **kwargs)
 
 
-def get_a_tab() -> AsyncTab:
-
-    for port in ChromeDaemon.port_in_using:
-        return Chrome(port=port).get_tab()
+def get_a_tab(host='127.0.0.1', port=None) -> AsyncTab:
+    if not port:
+        for port in ChromeDaemon.port_in_using:
+            return Chrome(port=port).get_tab()
+        port = 9222
     try:
-        return Chrome().get_tab()
+        return Chrome(host=host, port=port).get_tab()
     except RuntimeError:
         # no existing port, launch a new chrome, and auto quit if chrome process missed.
         launch()
-        return Chrome().get_tab()
+        return Chrome(host=host, port=port).get_tab()
 
 
 def show_all_log():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 psutil
 torequests>=5.0.6
 websocket-client
-aiofiles


### PR DESCRIPTION
tab.wait_response can contains response body
refactor timeout and connect_timeout logic
Tab.js return result.result by default
tab.js add value_path
Chrome.get_memory
add kwargs for Tab.send
rename get_data_value's path to value_path
methods with prefix `wait_` the `timeout` default to None
support using system default user dir
add js_code for js function snippets
clear dir support port arg for unique clean
show user dir size on launching
